### PR TITLE
Allow set the breakpoint width

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -32,7 +32,8 @@ $.AdminBSB.options = {
         scrollWidth: '4px',
         scrollAlwaysVisible: false,
         scrollBorderRadius: '0',
-        scrollRailBorderRadius: '0'
+        scrollRailBorderRadius: '0',
+        breakpointWidth: '1170'
     },
     dropdownMenu: {
         effectIn: 'fadeIn',
@@ -135,7 +136,7 @@ $.AdminBSB.leftSideBar = {
             });
         }
 
-        if (width < 1170) {
+        if (width < $.AdminBSB.options.leftSideBar.breakpointWidth) {
             $body.addClass('ls-closed');
             $openCloseBar.fadeIn();
         }


### PR DESCRIPTION
Default width to hide the slide-bar is too high. Just opening the inspector view hides the slide-bar.
Please allow set the breakpoint width by developers.