### PR TITLE
Fix floating label position

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -275,6 +275,13 @@ $.AdminBSB.input = {
         $('body').on('click', '.form-float .form-line .form-label', function () {
             $(this).parent().find('input').focus();
         });
+
+        //Not blank form
+        $('.form-control').each(function() {
+          if ($(this).val() !== '') {
+            $(this).parent('.form-line').addClass('focused');
+          }
+        });
     }
 }
 //==========================================================================================================================


### PR DESCRIPTION
If exist some not-blank forms when the page load started, (for example, the edit profile page), you will see the following strange view.

<img width="361" alt="sc 346" src="https://cloud.githubusercontent.com/assets/11713748/23093169/0117fbfc-f61f-11e6-81bf-c89ec25998fe.png">

This pull request fixes that problem, and then you will see the following view when the page load finished.

<img width="265" alt="sc 347" src="https://cloud.githubusercontent.com/assets/11713748/23093225/6b82e5d2-f620-11e6-821c-4f5d8bc186ad.png">
