### PR TITLE
Enable multi-level input activation

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -262,7 +262,7 @@ $.AdminBSB.input = {
     activate: function () {
         //On focus event
         $('.form-control').focus(function () {
-            $(this).parent().addClass('focused');
+            $(this).closest('.form-line').addClass('focused');
         });
 
         //On focusout event


### PR DESCRIPTION
In some scenarios, form-control won't exist as a direct child of form-line. In these scenarios, focus binding requires to search for the closest `.form-line` parent